### PR TITLE
Redis for config and user & no extra_data

### DIFF
--- a/apis/account/schemas.go
+++ b/apis/account/schemas.go
@@ -56,5 +56,6 @@ type ModifyUserRequest struct {
 	*PhoneModel           `validate:"omitempty"`
 	Verification          string          `json:"verification" minLength:"6" maxLength:"6" validate:"omitempty,len=6"`
 	DisableSensitiveCheck *bool           `json:"disable_sensitive_check"`
+	ModelID               *int            `json:"model_id" validate:"omitempty,min=1"`
 	PluginConfig          map[string]bool `json:"plugin_config" validate:"omitempty"`
 }

--- a/apis/account/token.go
+++ b/apis/account/token.go
@@ -92,7 +92,7 @@ func Logout(c *fiber.Ctx) error {
 	_, messageCollection := GetInfoByIP(GetRealIP(c))
 
 	var user User
-	err = DB.Take(&user, userID).Error
+	err = LoadUserByIDFromCache(userID, &user)
 	if err != nil {
 		return err
 	}

--- a/apis/account/user.go
+++ b/apis/account/user.go
@@ -5,6 +5,7 @@ import (
 	. "MOSS_backend/models"
 	. "MOSS_backend/utils"
 	"MOSS_backend/utils/auth"
+
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/gorm"
 )
@@ -99,11 +100,22 @@ func ModifyUser(c *fiber.Ctx) error {
 			}
 		}
 
+		if body.ModelID != nil {
+			if user.ModelID == 0 {
+				user.ModelID = 1
+			}
+			user.ModelID = *body.ModelID
+		}
+
 		return tx.Save(&user).Error
 	})
+
 	if err != nil {
 		return err
 	}
+
+	// redis update
+	config.SetCache(GetUserCacheKey(user.ID), user, UserCacheExpire)
 
 	return c.JSON(user)
 }

--- a/apis/config/config.go
+++ b/apis/config/config.go
@@ -44,7 +44,6 @@ func GetConfig(c *fiber.Ctx) error {
 // @Tags Config
 // @Produce json
 // @Router /config [put]
-// @Param json body UpdateConfigRequest true "json"
 // @Success 200 {object} Response
 // @Failure 400 {object} Response
 // @Failure 500 {object} Response

--- a/apis/config/config.go
+++ b/apis/config/config.go
@@ -43,7 +43,7 @@ func GetConfig(c *fiber.Ctx) error {
 // @Summary update global config
 // @Tags Config
 // @Produce json
-// @Router /config [put]
+// @Router /config [patch]
 // @Success 200 {object} Response
 // @Failure 400 {object} Response
 // @Failure 500 {object} Response

--- a/apis/config/config.go
+++ b/apis/config/config.go
@@ -39,11 +39,13 @@ func GetConfig(c *fiber.Ctx) error {
 	})
 }
 
-// UpdateConfig
+// PatchConfig
 // @Summary update global config
 // @Tags Config
+// @Accept json
 // @Produce json
 // @Router /config [patch]
+// @Param json body ModifyModelConfigRequest true "body"
 // @Success 200 {object} Response
 // @Failure 400 {object} Response
 // @Failure 500 {object} Response

--- a/apis/config/routes.go
+++ b/apis/config/routes.go
@@ -5,5 +5,5 @@ import "github.com/gofiber/fiber/v2"
 func RegisterRoutes(routes fiber.Router) {
 	routes.Get("/config", GetConfig)
 	// redis update & config update
-	routes.Put("/config", PatchConfig)
+	routes.Patch("/config", PatchConfig)
 }

--- a/apis/config/routes.go
+++ b/apis/config/routes.go
@@ -4,4 +4,6 @@ import "github.com/gofiber/fiber/v2"
 
 func RegisterRoutes(routes fiber.Router) {
 	routes.Get("/config", GetConfig)
+	// redis update & config update
+	routes.Put("/config", PatchConfig)
 }

--- a/apis/config/schemas.go
+++ b/apis/config/schemas.go
@@ -6,3 +6,16 @@ type Response struct {
 	Notice              string          `json:"notice"`
 	DefaultPluginConfig map[string]bool `json:"default_plugin_config"`
 }
+
+type ModelConfigRequset struct {
+	ID                       *int    `json:"id" validate:"min=1"`
+	InnerThoughtsPostprocess *bool   `json:"inner_thoughts_postprocess" validate:"omitempty,oneof=true false"`
+	Description              *string `json:"description" validate:"omitempty"`
+}
+
+type ModifyModelConfigRequest struct {
+	InviteRequired *bool                 `json:"invite_required" validate:"omitempty,oneof=true false"`
+	OffenseCheck   *bool                 `json:"offense_check" validate:"omitempty,oneof=true false"`
+	Notice         *string               `json:"notice" validate:"omitempty"`
+	ModelConfig    []*ModelConfigRequset `json:"model_config" validate:"omitempty"`
+}

--- a/apis/config/schemas.go
+++ b/apis/config/schemas.go
@@ -7,7 +7,7 @@ type Response struct {
 	DefaultPluginConfig map[string]bool `json:"default_plugin_config"`
 }
 
-type ModelConfigRequset struct {
+type ModelConfigRequest struct {
 	ID                       *int    `json:"id" validate:"min=1"`
 	InnerThoughtsPostprocess *bool   `json:"inner_thoughts_postprocess" validate:"omitempty,oneof=true false"`
 	Description              *string `json:"description" validate:"omitempty"`
@@ -17,5 +17,5 @@ type ModifyModelConfigRequest struct {
 	InviteRequired *bool                 `json:"invite_required" validate:"omitempty,oneof=true false"`
 	OffenseCheck   *bool                 `json:"offense_check" validate:"omitempty,oneof=true false"`
 	Notice         *string               `json:"notice" validate:"omitempty"`
-	ModelConfig    []*ModelConfigRequset `json:"model_config" validate:"omitempty"`
+	ModelConfig    []*ModelConfigRequest `json:"model_config" validate:"omitempty"`
 }

--- a/apis/record/infer.go
+++ b/apis/record/infer.go
@@ -10,9 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gofiber/websocket/v2"
-	"github.com/google/uuid"
-	"go.uber.org/zap"
 	"io"
 	"log"
 	"net/http"
@@ -21,6 +18,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/gofiber/websocket/v2"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
 )
 
 var endContentRegexp = regexp.MustCompile(`<[es]o\w>`)
@@ -162,7 +163,7 @@ func InferCommon(
 	results, err := tools.Execute(ctx.c, commandContent)
 
 	// replace invalid commands output
-	if errors.Is(err, tools.CommandsFormatError) {
+	if errors.Is(err, tools.ErrInvalidCommandFormat) {
 		Logger.Error(
 			`error commands format`,
 			zap.String("command", commandContent),

--- a/config/cache.go
+++ b/config/cache.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/eko/gocache/lib/v4/cache"
+	"github.com/eko/gocache/lib/v4/store"
+	gocacheStore "github.com/eko/gocache/store/go_cache/v4"
+	redisStore "github.com/eko/gocache/store/redis/v4"
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/redis/go-redis/v9"
+	"time"
+)
+
+var Cache *cache.Cache[[]byte]
+
+func initCache() {
+	if Config.RedisUrl != "" {
+		Cache = cache.New[[]byte](
+			redisStore.NewRedis(
+				redis.NewClient(
+					&redis.Options{
+						Addr: Config.RedisUrl,
+					},
+				),
+			),
+		)
+		fmt.Println("using redis")
+	} else {
+		Cache = cache.New[[]byte](
+			gocacheStore.NewGoCache(
+				gocache.New(
+					10*time.Minute,
+					20*time.Minute),
+			),
+		)
+		fmt.Println("using gocache")
+	}
+}
+
+func GetCache(key string, model any) error {
+	data, err := Cache.Get(context.Background(), key)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, &model)
+}
+
+func SetCache(key string, model any, duration time.Duration) error {
+	data, err := json.Marshal(model)
+	if err != nil {
+		return err
+	}
+	return Cache.Set(context.Background(), key, data, store.WithExpiration(duration))
+}

--- a/config/cache.go
+++ b/config/cache.go
@@ -10,6 +10,7 @@ import (
 	redisStore "github.com/eko/gocache/store/redis/v4"
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/redis/go-redis/v9"
+	"math/rand"
 	"time"
 )
 
@@ -53,5 +54,18 @@ func SetCache(key string, model any, duration time.Duration) error {
 	if err != nil {
 		return err
 	}
+	duration = GenRandomDuration(duration)
 	return Cache.Set(context.Background(), key, data, store.WithExpiration(duration))
+}
+
+func DeleteCache(key string) error {
+	return Cache.Delete(context.Background(), key)
+}
+
+func ClearCache() error {
+	return Cache.Clear(context.Background())
+}
+
+func GenRandomDuration(delay time.Duration) time.Duration {
+	return delay + time.Duration(rand.Int63n(int64(900 * time.Second)))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ var Config struct {
 	UniSignature  string `env:"UNI_SIGNATURE" envDefault:"fastnlp"`
 	UniTemplateID string `env:"UNI_TEMPLATE_ID,required"`
 
-	InferenceUrl string `env:"INFERENCE_URL,required"`
+	// InferenceUrl string `env:"INFERENCE_URL,required"` // now save it in db
 
 	// 敏感信息检测
 	EnableSensitiveCheck   bool   `env:"ENABLE_SENSITIVE_CHECK" envDefault:"true"`
@@ -58,7 +58,7 @@ var Config struct {
 
 	DefaultPluginConfig map[string]bool `env:"DEFAULT_PLUGIN_CONFIG"`
 
-	InnerThoughtsPostprocess bool `env:"INNER_THOUGHTS_POSTPROCESS" envDefault:"false"`
+	// InnerThoughtsPostprocess bool `env:"INNER_THOUGHTS_POSTPROCESS" envDefault:"false"`
 }
 
 func InitConfig() {

--- a/config/config.go
+++ b/config/config.go
@@ -67,4 +67,6 @@ func InitConfig() {
 		panic(err)
 	}
 	fmt.Printf("%+v\n", &Config)
+
+	initCache()
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -253,6 +253,35 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "update global config",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    }
+                }
             }
         },
         "/inference": {
@@ -826,6 +855,10 @@ const docTemplate = `{
                 "email": {
                     "type": "string"
                 },
+                "model_id": {
+                    "type": "integer",
+                    "minimum": 1
+                },
                 "nickname": {
                     "type": "string",
                     "minLength": 1
@@ -987,7 +1020,6 @@ const docTemplate = `{
                     "description": "处理时间，单位 s",
                     "type": "number"
                 },
-                "extra_data": {},
                 "feedback": {
                     "type": "string"
                 },
@@ -998,9 +1030,7 @@ const docTemplate = `{
                     "description": "1 like, -1 dislike",
                     "type": "integer"
                 },
-                "raw_content": {
-                    "type": "string"
-                },
+                "processed_extra_data": {},
                 "request": {
                     "type": "string"
                 },
@@ -1045,6 +1075,10 @@ const docTemplate = `{
                 "last_login": {
                     "type": "string"
                 },
+                "model_id": {
+                    "type": "integer",
+                    "default": 1
+                },
                 "nickname": {
                     "type": "string"
                 },
@@ -1078,6 +1112,12 @@ const docTemplate = `{
             "properties": {
                 "context": {
                     "type": "string"
+                },
+                "plugin_config": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "request": {
                     "type": "string",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -254,7 +254,7 @@ const docTemplate = `{
                     }
                 }
             },
-            "put": {
+            "patch": {
                 "produces": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -255,6 +255,9 @@ const docTemplate = `{
                 }
             },
             "patch": {
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -262,6 +265,17 @@ const docTemplate = `{
                     "Config"
                 ],
                 "summary": "update global config",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "json",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/config.ModifyModelConfigRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -947,6 +961,53 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "minLength": 1
+                }
+            }
+        },
+        "config.ModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "inner_thoughts_postprocess": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
+                }
+            }
+        },
+        "config.ModifyModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "invite_required": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
+                "model_config": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/config.ModelConfigRequest"
+                    }
+                },
+                "notice": {
+                    "type": "string"
+                },
+                "offense_check": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -248,6 +248,9 @@
                 }
             },
             "patch": {
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -255,6 +258,17 @@
                     "Config"
                 ],
                 "summary": "update global config",
+                "parameters": [
+                    {
+                        "description": "body",
+                        "name": "json",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/config.ModifyModelConfigRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -940,6 +954,53 @@
                 "name": {
                     "type": "string",
                     "minLength": 1
+                }
+            }
+        },
+        "config.ModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "inner_thoughts_postprocess": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
+                }
+            }
+        },
+        "config.ModifyModelConfigRequest": {
+            "type": "object",
+            "properties": {
+                "invite_required": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
+                "model_config": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/config.ModelConfigRequest"
+                    }
+                },
+                "notice": {
+                    "type": "string"
+                },
+                "offense_check": {
+                    "type": "boolean",
+                    "enum": [
+                        true,
+                        false
+                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -247,7 +247,7 @@
                     }
                 }
             },
-            "put": {
+            "patch": {
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -246,6 +246,35 @@
                         }
                     }
                 }
+            },
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Config"
+                ],
+                "summary": "update global config",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/config.Response"
+                        }
+                    }
+                }
             }
         },
         "/inference": {
@@ -819,6 +848,10 @@
                 "email": {
                     "type": "string"
                 },
+                "model_id": {
+                    "type": "integer",
+                    "minimum": 1
+                },
                 "nickname": {
                     "type": "string",
                     "minLength": 1
@@ -980,7 +1013,6 @@
                     "description": "处理时间，单位 s",
                     "type": "number"
                 },
-                "extra_data": {},
                 "feedback": {
                     "type": "string"
                 },
@@ -991,9 +1023,7 @@
                     "description": "1 like, -1 dislike",
                     "type": "integer"
                 },
-                "raw_content": {
-                    "type": "string"
-                },
+                "processed_extra_data": {},
                 "request": {
                     "type": "string"
                 },
@@ -1038,6 +1068,10 @@
                 "last_login": {
                     "type": "string"
                 },
+                "model_id": {
+                    "type": "integer",
+                    "default": 1
+                },
                 "nickname": {
                     "type": "string"
                 },
@@ -1071,6 +1105,12 @@
             "properties": {
                 "context": {
                     "type": "string"
+                },
+                "plugin_config": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "boolean"
+                    }
                 },
                 "request": {
                     "type": "string",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -20,6 +20,9 @@ definitions:
         type: boolean
       email:
         type: string
+      model_id:
+        minimum: 1
+        type: integer
       nickname:
         minLength: 1
         type: string
@@ -133,7 +136,6 @@ definitions:
       duration:
         description: 处理时间，单位 s
         type: number
-      extra_data: {}
       feedback:
         type: string
       id:
@@ -141,8 +143,7 @@ definitions:
       like_data:
         description: 1 like, -1 dislike
         type: integer
-      raw_content:
-        type: string
+      processed_extra_data: {}
       request:
         type: string
       request_sensitive:
@@ -172,6 +173,9 @@ definitions:
         type: string
       last_login:
         type: string
+      model_id:
+        default: 1
+        type: integer
       nickname:
         type: string
       phone:
@@ -194,6 +198,10 @@ definitions:
     properties:
       context:
         type: string
+      plugin_config:
+        additionalProperties:
+          type: boolean
+        type: object
       request:
         minLength: 1
         type: string
@@ -383,6 +391,25 @@ paths:
           schema:
             $ref: '#/definitions/config.Response'
       summary: get global config
+      tags:
+      - Config
+    put:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/config.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/config.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/config.Response'
+      summary: update global config
       tags:
       - Config
   /inference:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -393,7 +393,7 @@ paths:
       summary: get global config
       tags:
       - Config
-    put:
+    patch:
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -89,6 +89,38 @@ definitions:
         minLength: 1
         type: string
     type: object
+  config.ModelConfigRequest:
+    properties:
+      description:
+        type: string
+      id:
+        minimum: 1
+        type: integer
+      inner_thoughts_postprocess:
+        enum:
+        - true
+        - false
+        type: boolean
+    type: object
+  config.ModifyModelConfigRequest:
+    properties:
+      invite_required:
+        enum:
+        - true
+        - false
+        type: boolean
+      model_config:
+        items:
+          $ref: '#/definitions/config.ModelConfigRequest'
+        type: array
+      notice:
+        type: string
+      offense_check:
+        enum:
+        - true
+        - false
+        type: boolean
+    type: object
   config.Response:
     properties:
       default_plugin_config:
@@ -394,6 +426,15 @@ paths:
       tags:
       - Config
     patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: body
+        in: body
+        name: json
+        required: true
+        schema:
+          $ref: '#/definitions/config.ModifyModelConfigRequest'
       produces:
       - application/json
       responses:

--- a/models/chat.go
+++ b/models/chat.go
@@ -29,8 +29,8 @@ type Record struct {
 	Request            string         `json:"request"`
 	Response           string         `json:"response"`
 	Prefix             string         `json:"-"`
-	RawContent         string         `json:"raw_content"`
-	ExtraData          any            `json:"extra_data" gorm:"serializer:json"`
+	RawContent         string         `json:"-"` //`json:"raw_content"`
+	ExtraData          any            `json:"-"` //`json:"extra_data" gorm:"serializer:json"`
 	ProcessedExtraData any            `json:"processed_extra_data" gorm:"serializer:json"`
 	LikeData           int            `json:"like_data"` // 1 like, -1 dislike
 	Feedback           string         `json:"feedback"`

--- a/models/config.go
+++ b/models/config.go
@@ -1,8 +1,38 @@
 package models
 
+import (
+	"MOSS_backend/config"
+	"log"
+	"time"
+)
+
 type Config struct {
-	ID             int
-	InviteRequired bool
-	OffenseCheck   bool
-	Notice         string
+	ID             int           `json:"-"`
+	InviteRequired bool          `json:"invite_required"`
+	OffenseCheck   bool          `json:"offense_check"`
+	Notice         string        `json:"notice"`
+	ModelConfig    []ModelConfig `json:"model_config"`
+}
+
+var configCacheName = "moss_backend_config"
+
+func LoadConfig() *Config {
+	var configObject Config
+	var modelConfig []ModelConfig
+	if config.GetCache(configCacheName, &configObject) != nil {
+		DB.First(&configObject)
+		DB.First(&modelConfig)
+		configObject.ModelConfig = modelConfig
+		err := config.SetCache(configCacheName, configObject, 24*time.Hour)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+	return &configObject
+}
+
+type ModelConfig struct {
+	ID          int    `json:"id"`
+	Description string `json:"description"`
+	Url         string `json:"-"`
 }

--- a/models/config.go
+++ b/models/config.go
@@ -7,9 +7,14 @@ import (
 )
 
 type ModelConfig struct {
-	ID          int    `json:"id"`
-	Description string `json:"description"`
-	Url         string `json:"-"`
+	ID                       int    `json:"id"`
+	InnerThoughtsPostprocess bool   `json:"inner_thoughts_postprocess" default:"false"`
+	Description              string `json:"description"`
+	Url                      string `json:"-"`
+}
+
+func (cfg *ModelConfig) TableName() string {
+	return "language_model_config"
 }
 
 type Config struct {

--- a/models/config.go
+++ b/models/config.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+type ModelConfig struct {
+	ID          int    `json:"id"`
+	Description string `json:"description"`
+	Url         string `json:"-"`
+}
+
 type Config struct {
 	ID             int           `json:"-"`
 	InviteRequired bool          `json:"invite_required"`
@@ -14,25 +20,33 @@ type Config struct {
 	ModelConfig    []ModelConfig `json:"model_config"`
 }
 
-var configCacheName = "moss_backend_config"
+const configCacheName = "moss_backend_config"
+const configCacheExpire = 24 * time.Hour
 
-func LoadConfig() *Config {
-	var configObject Config
-	var modelConfig []ModelConfig
-	if config.GetCache(configCacheName, &configObject) != nil {
-		DB.First(&configObject)
-		DB.First(&modelConfig)
-		configObject.ModelConfig = modelConfig
-		err := config.SetCache(configCacheName, configObject, 24*time.Hour)
+func LoadConfig(configObjectPtr *Config) error {
+	if config.GetCache(configCacheName, configObjectPtr) != nil {
+		if err := DB.First(configObjectPtr).Error; err != nil {
+			return err
+		}
+		if err := DB.First(&(configObjectPtr.ModelConfig)).Error; err != nil {
+			return err
+		}
+		err := config.SetCache(configCacheName, configObjectPtr, configCacheExpire)
 		if err != nil {
 			log.Println(err)
 		}
 	}
-	return &configObject
+	return nil
 }
 
-type ModelConfig struct {
-	ID          int    `json:"id"`
-	Description string `json:"description"`
-	Url         string `json:"-"`
+func UpdateConfig(configObject *Config) error {
+	err := DB.Model(&Config{}).Updates(configObject).Error
+	if err != nil {
+		return err
+	}
+	err = config.SetCache(configCacheName, configObject, configCacheExpire)
+	if err != nil {
+		log.Println(err)
+	}
+	return nil
 }

--- a/models/init.go
+++ b/models/init.go
@@ -99,4 +99,9 @@ func InitDB() {
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		DB.Create(&configObject)
 	}
+	var configModelObject ModelConfig
+	err = DB.First(&configModelObject).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		DB.Create(&configModelObject)
+	}
 }

--- a/models/user_offense.go
+++ b/models/user_offense.go
@@ -37,7 +37,7 @@ func (user *User) CheckUserOffense() (bool, error) {
 	)
 
 	var configObject Config
-	err = DB.First(&configObject).Error
+	err = LoadConfig(&configObject)
 	if err != nil {
 		return false, err
 	}

--- a/utils/tools/calculate.go
+++ b/utils/tools/calculate.go
@@ -6,11 +6,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strconv"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type keyNotExistError struct {
@@ -63,20 +64,20 @@ func (t *calculateTask) request() {
 	res, err := calculateHttpClient.Post(config.Config.ToolsCalculateUrl, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		utils.Logger.Error("post calculate(tools) error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	if res.StatusCode != 200 {
 		utils.Logger.Error("post calculate(tools) status code error: " + strconv.Itoa(res.StatusCode))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	responseData, err := io.ReadAll(res.Body)
 	if err != nil {
 		utils.Logger.Error("post calculate(tools) response read error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
@@ -84,24 +85,24 @@ func (t *calculateTask) request() {
 	err = json.Unmarshal(responseData, &results)
 	if err != nil {
 		utils.Logger.Error("post calculate(tools) response unmarshal error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	calculateResult, exist := results["result"]
 	if !exist {
 		utils.Logger.Error("post calculate(tools) response format error: ", zap.Error(keyNotExistError{Results: results}))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	resultsString, ok := calculateResult.(string)
 	if !ok {
 		utils.Logger.Error("post calculate(tools) response format error: ", zap.Error(resultNotStringError{Results: results}))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	if _, err := strconv.ParseFloat(resultsString, 32); err != nil {
 		utils.Logger.Error("post calculate(tools) response not number error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 

--- a/utils/tools/draw.go
+++ b/utils/tools/draw.go
@@ -5,14 +5,15 @@ import (
 	"MOSS_backend/utils"
 	"bytes"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/vmihailenco/msgpack/v5"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/vmihailenco/msgpack/v5"
+	"go.uber.org/zap"
 )
 
 //func main() {
@@ -58,31 +59,31 @@ func (t *drawTask) request() {
 	reqBody, err := msgpack.Marshal(t.args)
 	if err != nil {
 		utils.Logger.Error("post draw(tools) prompt cannot marshal error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	res, err := drawHttpClient.Post(config.Config.ToolsDrawUrl, "application/x-msgpack", bytes.NewBuffer(reqBody))
 	if err != nil {
 		utils.Logger.Error("post draw(tools) error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	if res.StatusCode != 200 {
 		utils.Logger.Error("post draw(tools) status code error: " + strconv.Itoa(res.StatusCode))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		utils.Logger.Error("post draw(tools) response body data cannot read error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	var resultsByte []byte
 	if err = msgpack.Unmarshal(data, &resultsByte); err != nil {
 		utils.Logger.Error("post draw(tools) response body data cannot Unmarshal error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 

--- a/utils/tools/main.go
+++ b/utils/tools/main.go
@@ -137,7 +137,10 @@ func (s *scheduler) NewTask(action string, args string) task {
 // sendCommandStatus
 // a filter. only inform frontend well-formed commands
 func sendCommandStatus(c *websocket.Conn, action, args, StatusString string) {
-
+	if c == nil {
+		utils.Logger.Error("no ws connection")
+		return
+	}
 	if err := c.WriteJSON(CommandStatusModel{
 		Status: 3, // 3 means `send command status`
 		Type:   action,

--- a/utils/tools/schema.go
+++ b/utils/tools/schema.go
@@ -49,4 +49,4 @@ type scheduler struct {
 	searchResultsIndex int
 }
 
-var defaultError = errors.New("default error")
+var ErrGeneric = errors.New("default error")

--- a/utils/tools/schema.go
+++ b/utils/tools/schema.go
@@ -12,8 +12,8 @@ type ResultModel struct {
 }
 
 type ResultTotalModel struct {
-	Result             string            `json:"result"`
-	ExtraData          []*ExtraDataModel `json:"extra_data"`
+	Result             string            `json:"-"` //`json:"result"`
+	ExtraData          []*ExtraDataModel `json:"-"` //`json:"extra_data"`
 	ProcessedExtraData []*ExtraDataModel `json:"processed_extra_data"`
 }
 

--- a/utils/tools/search.go
+++ b/utils/tools/search.go
@@ -6,13 +6,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 /*
@@ -180,20 +181,20 @@ func (t *searchTask) request() {
 	res, err := searchHttpClient.Post(config.Config.ToolsSearchUrl, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		utils.Logger.Error("post search error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	if res.StatusCode != 200 {
 		utils.Logger.Error("post search status code error: " + strconv.Itoa(res.StatusCode))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	responseData, err := io.ReadAll(res.Body)
 	if err != nil {
 		utils.Logger.Error("post search response read error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	// result processing
@@ -201,7 +202,7 @@ func (t *searchTask) request() {
 	err = json.Unmarshal(responseData, &results)
 	if err != nil {
 		utils.Logger.Error("post search response unmarshal error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 

--- a/utils/tools/solve.go
+++ b/utils/tools/solve.go
@@ -5,11 +5,12 @@ import (
 	"MOSS_backend/utils"
 	"bytes"
 	"encoding/json"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strconv"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type solveTask struct {
@@ -46,20 +47,20 @@ func (t *solveTask) request() {
 	res, err := solveHttpClient.Post(config.Config.ToolsSolveUrl, "application/json", bytes.NewBuffer(data))
 	if err != nil {
 		utils.Logger.Error("post solve(tools) error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	if res.StatusCode != 200 {
 		utils.Logger.Error("post solve(tools) status code error: " + strconv.Itoa(res.StatusCode))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	responseData, err := io.ReadAll(res.Body)
 	if err != nil {
 		utils.Logger.Error("post solve(tools) response read error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
@@ -67,25 +68,25 @@ func (t *solveTask) request() {
 	err = json.Unmarshal(responseData, &results)
 	if err != nil {
 		utils.Logger.Error("post solve(tools) response unmarshal error: ", zap.Error(err))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 
 	solveResult, exist := results["result"]
 	if !exist {
 		utils.Logger.Error("post solve(tools) response format error: ", zap.Error(keyNotExistError{Results: results}))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	resultsString, ok := solveResult.(string)
 	if !ok {
 		utils.Logger.Error("post solve(tools) response format error: ", zap.Error(resultNotStringError{Results: results}))
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 	if resultsString == `[ERROR]` || resultsString == "" {
 		utils.Logger.Warn("post solve(tools) request no solution")
-		t.err = defaultError
+		t.err = ErrGeneric
 		return
 	}
 


### PR DESCRIPTION
1. 新建一个api用于缓存修改：PATCH /api/config。网关加上 apikey 鉴权插件。
  - PATCH /api/settings，对应handler PatchConfig, apis/account/routes.go
  - 可以任意的改，若是modelConfig则需要额外用model的ID，且ID用string发送。
2. user model下新建字段，设置模型编号，默认1
  - 模型编号实际上就是数据库里的主键，数据库已准备好
  - 根据用户的不同选择启用相应模型的 inferUrl
3. config返回模型信息给前端
  -  数据结构：使用 models/config.go 中的 Config 的 ModelConfig 返回，本质上是一个列表
  -  Get /api/config 返回 models/config.go 中的 Config （和plugin一样）
4. PUT /api/users/me 修改用户配置
  -  apis/account/user.go L38，为handler, 目前的逻辑是直接访问数据库修改，然后修改redis
  -  其余相当于修改配置的地方，要删除cache，含：用户注销，用户手机号修改、用户邮箱修改
  -  用户密码修改时，删除cache
5. 为每个缓存条目的 expire duration 加上 [0, 900*1000] 毫秒的随机延迟
6. 修改所有加载数据库 config 的地方用model.LoadConfig方法
  -  AutoMerge 处做了额外修改
8. inner thought 第二轮是否置为 none 变成模型的属性，存放在 ModelConfig 中
9. 更新了 swag 